### PR TITLE
Replace RuleBot's "舦" characters with bullets

### DIFF
--- a/cogs/other_bots/rules.py
+++ b/cogs/other_bots/rules.py
@@ -111,7 +111,7 @@ r.reload_rules          Fetch the rules from Google Drive and update the local c
                         await message.channel.send(m)
 
     def escape(self, message):
-        return message.replace('@', '@\u200b').replace('`', '\\`').replace('*', '\\*').replace('_', '\\_')
+        return message.replace('@', '@\u200b').replace('`', '\\`').replace('*', '\\*').replace('_', '\\_').replace('舦', ' •')
 
     def lookup_rule(self, code):
         if len(code) < 2:


### PR DESCRIPTION
hanss suggested that I do this so here it is

This is for whenever it tries to post an unordered list from Google Docs but uses "舦" in the place of the bullets